### PR TITLE
build: update rollup config and package metadata for v2 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,14 @@
   "version": "1.0.0",
   "type": "module",
   "description": "Lightweight string‑to‑string date format converter with pluggable tokens",
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/cjs/index.cjs.js",
+  "module": "dist/esm/index.esm.js",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.esm.js",
+      "require": "./dist/cjs/index.cjs.js"
+    }
+  },
   "scripts": {
     "clean": "rimraf dist",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir dist/cjs --extensions \".js,.mjs\"",
@@ -30,6 +36,14 @@
     "formatter"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sathvikc/datefmt-lite.git"
+  },
+  "bugs": {
+    "url": "https://github.com/sathvikc/datefmt-lite/issues"
+  },
+  "homepage": "https://github.com/sathvikc/datefmt-lite#readme",
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.27.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ import { terser } from 'rollup-plugin-terser';
 export default [
   {
     input: 'src/index.js',
-    output: { file: 'dist/index.cjs.js', format: 'cjs', exports: 'named' },
+    output: { file: 'dist/cjs/index.cjs.js', format: 'cjs', exports: 'named' },
     plugins: [
       // 1) let Rollup resolve ./compiler.js, ./parser.js, etc.
       resolve({ extensions: ['.js', '.mjs'] }),
@@ -24,7 +24,7 @@ export default [
   },
   {
     input: 'src/index.js',
-    output: { file: 'dist/index.esm.js', format: 'esm' },
+    output: { file: 'dist/esm/index.esm.js', format: 'esm' },
     plugins: [
       resolve({ extensions: ['.js', '.mjs'] }),
       commonjs(),


### PR DESCRIPTION
## 🔧 Build Config Update for v2 Release

This PR prepares the project for the `v2.0.0` release by updating the build setup and package metadata.

---

### ✅ Changes

- Updated Rollup config to output files into `dist/cjs` and `dist/esm`
- Updated `package.json`:
  - Added `exports` map for modern ESM/CJS resolution
  - Updated `main` and `module` paths to match new output
  - Added `repository`, `bugs`, and `homepage` fields

---

### 📦 Notes

- No runtime logic was changed
- This PR only touches build and packaging configuration
- Follow-up: `v2.0.0` version bump and publish to npm
